### PR TITLE
Installing missing libffi6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
     env:
       DB: ${{ matrix.db }}
       RAILS_ENV: test
+      BUNDLE_WITH: ${{ matrix.db }}
+      BUNDLE_WITHOUT: development
+      BUNDLE_FROZEN: true
+      BUNDLE_DISABLE_SHARED_GEMS: true
     services:
       postgres:
         image: postgres
@@ -48,15 +52,9 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
       - name: Prepare
         run: script/ci/prepare.sh
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: bundler-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.db }}-${{ hashFiles('Gemfile.lock') }}
-      - name: Install dependencies
-        run: bundle
       - name: Run tests
         run: bin/rake --trace ci:${{ matrix.kind }}
       - name: Run Jasmine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,12 @@ jobs:
           - 5432:5432
     steps:
       - name: Install system dependencies
-        run: sudo apt-get install -y build-essential curl git gsfonts imagemagick libcurl4-openssl-dev libidn11-dev libmagickwand-dev libssl-dev libxml2-dev libxslt1-dev
+        run: | 
+          sudo apt-get install -y build-essential curl git gsfonts imagemagick libmysqlclient-dev libcurl4-openssl-dev libidn11-dev libmagickwand-dev libssl-dev libxml2-dev libxslt1-dev
+      - name: Re-install libffi.so.6 a
+        run: |
+          wget http://mirrors.edge.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
+          sudo apt-get install ./libffi6_3.2.1-8_amd64.deb
       - name: Start MySQL
         run: sudo systemctl start mysql.service
         if: matrix.db == 'mysql'

--- a/script/ci/prepare.sh
+++ b/script/ci/prepare.sh
@@ -6,6 +6,3 @@ cp config/database.yml.example config/database.yml
 if [ "${DB}" = "mysql" ]; then
   sed -i 's/*common/*mysql/' config/database.yml
 fi
-
-gem install bundler
-script/configure_bundler


### PR DESCRIPTION
CI builds on 'latest'. Since 20.x the needed libffi6 package was updates to 7 - but still used by some deps.  
This (tries) installs libffi6 on build. 
 Fixes Issue #8221